### PR TITLE
feat(sdk): add EUROMAIL_API_KEY env var support and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.2] - 2026-04-13
+
+### Added
+
+- `getEmailLinks` method to retrieve click statistics for tracked links in a sent email.
+- `generateInsights` method to generate deliverability insight reports.
+- `LinkClickStat`, `InsightSeverity`, `InsightArea`, `InsightFinding`, and `InsightReport` types.
+
+## [0.1.1] - 2026-04-12
+
+### Fixed
+
+- Added CommonJS `require` export for compatibility with non-ESM projects.
+- Updated repository URLs to point to the correct GitHub location.
+
+## [0.1.0] - 2026-04-11
+
+### Added
+
+- Initial release of the `@euromail/sdk` TypeScript SDK.
+- Full API coverage: emails, templates, domains, webhooks, suppressions, contact lists, newsletters, signup forms, analytics, audit logs, dead letters, inbound email, API keys, billing, GDPR, and email validation.
+- Typed error classes: `EuroMailError`, `AuthenticationError`, `ValidationError`, `RateLimitError`.
+- Automatic `EUROMAIL_API_URL` environment variable support for base URL.
+- Configurable timeout with 30-second default.

--- a/src/client.ts
+++ b/src/client.ts
@@ -73,7 +73,7 @@ import type {
 } from "./types.js";
 
 export interface EuroMailConfig {
-  apiKey: string;
+  apiKey?: string;
   baseUrl?: string;
   timeout?: number;
 }
@@ -94,11 +94,17 @@ export class EuroMail {
   private readonly baseUrl: string;
   private readonly timeout: number;
 
-  constructor(config: EuroMailConfig) {
-    if (!config.apiKey) {
-      throw new Error("apiKey is required");
+  constructor(config: EuroMailConfig = {}) {
+    const resolvedApiKey =
+      config.apiKey ??
+      (typeof process !== "undefined" ? process.env?.EUROMAIL_API_KEY : undefined);
+
+    if (!resolvedApiKey) {
+      throw new Error(
+        "EuroMail API key is required. Pass it as `apiKey` in the constructor config or set the EUROMAIL_API_KEY environment variable."
+      );
     }
-    this.apiKey = config.apiKey;
+    this.apiKey = resolvedApiKey;
     this.baseUrl = resolveBaseUrl(config.baseUrl).replace(/\/+$/, "");
     if (!this.baseUrl.startsWith("https://") && !this.baseUrl.startsWith("http://localhost") && !this.baseUrl.startsWith("http://127.0.0.1")) {
       console.warn("WARNING: EuroMail base URL does not use HTTPS. API keys will be sent in cleartext.");


### PR DESCRIPTION
## Summary

- **EUROMAIL_API_KEY env var support**: The `EuroMail` constructor now automatically reads the API key from the `EUROMAIL_API_KEY` environment variable when no `apiKey` is passed in the config. The `apiKey` config field is now optional. A clear error message is shown when neither source provides a key.
- **CHANGELOG.md**: Added a changelog covering all releases (0.1.0 through 0.1.2) in Keep a Changelog format.

## Test plan

- [ ] Verify `new EuroMail()` reads from `EUROMAIL_API_KEY` env var
- [ ] Verify `new EuroMail({ apiKey: "..." })` still works and takes precedence
- [ ] Verify descriptive error when neither config nor env var provides a key
- [ ] Verify CHANGELOG.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)