### PR TITLE
docs: add agent mailbox notice with lease/ack/nack example

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,48 @@ try {
 | | `exportAccount()` | Export all account data |
 | | `deleteAccount()` | Permanently delete account |
 
+## Agent Mailboxes
+
+Agent mailboxes provide persistent email addresses for AI agents with at-least-once message delivery via a lease/ack/nack model. Native SDK support is coming in a future release. In the meantime, use `fetch` directly:
+
+```typescript
+const API = "https://api.euromail.dev";
+const KEY = process.env.EUROMAIL_API_KEY!;
+const headers = { "X-EuroMail-Api-Key": KEY, "Content-Type": "application/json" };
+
+// Create a mailbox
+const mailbox = await fetch(`${API}/v1/agent-mailboxes`, {
+  method: "POST",
+  headers,
+  body: JSON.stringify({ display_name: "Support Agent" }),
+}).then(r => r.json()).then(b => b.data);
+
+// Long-poll for the next message (acquires a 5-minute lease)
+const res = await fetch(`${API}/v1/agent-mailboxes/${mailbox.id}/messages/next?timeout=30`, { headers });
+if (res.status === 408) return; // no message, poll again
+const { data: msg, lease_token } = await res.json();
+
+try {
+  await handle(msg);
+  // Ack when done — message will not be redelivered
+  await fetch(`${API}/v1/agent-mailboxes/${mailbox.id}/messages/${msg.id}/ack`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ lease_token }),
+  });
+} catch (err) {
+  // Nack to return the message to the queue for retry
+  await fetch(`${API}/v1/agent-mailboxes/${mailbox.id}/messages/${msg.id}/nack`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ lease_token }),
+  });
+  throw err;
+}
+```
+
+See the [Agent Mailboxes guide](https://euromail.dev/docs/guides/agent-mailboxes/) for the full flow, duplicate handling, and horizontal scaling patterns.
+
 ## Requirements
 
 - Node.js 18+ (uses native `fetch`)


### PR DESCRIPTION
## Summary
- Adds an "Agent Mailboxes" section to the README before "Requirements"
- Notes that native SDK support is coming and shows a `fetch`-based example covering create, long-poll, ack, and nack
- Links to the full Agent Mailboxes guide for duplicate handling and horizontal scaling

## Test plan
- [ ] Render README on GitHub and verify the new section appears before Requirements
- [ ] Confirm the code block highlights as TypeScript and the guide link resolves

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>