### PR TITLE
feat: add agent mailbox support with lease/ack/nack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-04-13
+
+### Added
+
+- Native agent mailbox support: `createMailbox`, `listMailboxes`, `getMailbox`, `deleteMailbox`, `listMessages`, `waitForNextMessage`, `deleteMessage`, `ackMessage`, `nackMessage`.
+- Long-poll `waitForNextMessage` returns `null` on HTTP 408 timeout so callers can loop without try/catch.
+- Types: `AgentMailbox`, `CreateAgentMailboxParams`, `ListAgentMailboxesParams`, `MailboxMessage`, `ListMailboxMessagesParams`, `WaitForNextMessageParams`, `LeasedMessage`.
+
 ## [0.1.2] - 2026-04-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -449,43 +449,41 @@ try {
 
 ## Agent Mailboxes
 
-Agent mailboxes provide persistent email addresses for AI agents with at-least-once message delivery via a lease/ack/nack model. Native SDK support is coming in a future release. In the meantime, use `fetch` directly:
+Agent mailboxes provide persistent email addresses for AI agents with at-least-once message delivery via a lease/ack/nack model. The SDK wraps the full lifecycle natively:
 
 ```typescript
-const API = "https://api.euromail.dev";
-const KEY = process.env.EUROMAIL_API_KEY!;
-const headers = { "X-EuroMail-Api-Key": KEY, "Content-Type": "application/json" };
+import { EuroMail } from "@euromail/sdk";
+
+const euromail = new EuroMail({ apiKey: process.env.EUROMAIL_API_KEY });
 
 // Create a mailbox
-const mailbox = await fetch(`${API}/v1/agent-mailboxes`, {
-  method: "POST",
-  headers,
-  body: JSON.stringify({ display_name: "Support Agent" }),
-}).then(r => r.json()).then(b => b.data);
+const mailbox = await euromail.createMailbox({ display_name: "Support Agent" });
 
-// Long-poll for the next message (acquires a 5-minute lease)
-const res = await fetch(`${API}/v1/agent-mailboxes/${mailbox.id}/messages/next?timeout=30`, { headers });
-if (res.status === 408) return; // no message, poll again
-const { data: msg, lease_token } = await res.json();
+// Long-poll loop for incoming messages
+while (true) {
+  const leased = await euromail.waitForNextMessage(mailbox.id, { timeout: 30 });
+  if (!leased) continue; // 408 timeout — no message arrived, poll again
 
-try {
-  await handle(msg);
-  // Ack when done — message will not be redelivered
-  await fetch(`${API}/v1/agent-mailboxes/${mailbox.id}/messages/${msg.id}/ack`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ lease_token }),
-  });
-} catch (err) {
-  // Nack to return the message to the queue for retry
-  await fetch(`${API}/v1/agent-mailboxes/${mailbox.id}/messages/${msg.id}/nack`, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({ lease_token }),
-  });
-  throw err;
+  const { data: msg, lease_token } = leased;
+  try {
+    await handle(msg);
+    // Ack when done — message will not be redelivered
+    await euromail.ackMessage(mailbox.id, msg.id, lease_token);
+  } catch (err) {
+    // Nack to return the message to the queue for retry
+    await euromail.nackMessage(mailbox.id, msg.id, lease_token);
+    throw err;
+  }
 }
 ```
+
+Other mailbox methods:
+
+- `listMailboxes({ limit, offset })` — list mailboxes on the account
+- `getMailbox(id)` — fetch a single mailbox
+- `deleteMailbox(id)` — remove a mailbox
+- `listMessages(mailboxId, { status, limit, offset })` — list messages without acquiring a lease
+- `deleteMessage(mailboxId, messageId)` — permanently delete a message
 
 See the [Agent Mailboxes guide](https://euromail.dev/docs/guides/agent-mailboxes/) for the full flow, duplicate handling, and horizontal scaling patterns.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@euromail/sdk",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@euromail/sdk",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@euromail/sdk",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Official TypeScript SDK for EuroMail transactional email service",
   "type": "module",
   "main": "dist/index.js",

--- a/src/__tests__/agent-mailboxes.test.ts
+++ b/src/__tests__/agent-mailboxes.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EuroMail } from "../client.js";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("createMailbox", () => {
+  it("creates a mailbox and unwraps envelope", async () => {
+    const client = new EuroMail({ apiKey: "em_test_key" });
+    const mailbox = {
+      id: "mbx_001",
+      account_id: "acct_1",
+      local_part: "agent-abc123",
+      domain: "inbox.euromail.dev",
+      address: "agent-abc123@inbox.euromail.dev",
+      display_name: "Support Agent",
+      created_at: "2026-04-13T00:00:00Z",
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: mailbox }),
+      headers: new Headers(),
+    });
+
+    const result = await client.createMailbox({ display_name: "Support Agent" });
+    expect(result).toEqual(mailbox);
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/v1/agent-mailboxes");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body.display_name).toBe("Support Agent");
+  });
+
+  it("sends an empty body when no params are provided", async () => {
+    const client = new EuroMail({ apiKey: "em_test_key" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ data: { id: "mbx_002" } }),
+      headers: new Headers(),
+    });
+    await client.createMailbox();
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({});
+  });
+});
+
+describe("waitForNextMessage", () => {
+  it("returns the leased message envelope on 200", async () => {
+    const client = new EuroMail({ apiKey: "em_test_key" });
+    const leased = {
+      data: {
+        id: "msg_001",
+        mailbox_id: "mbx_001",
+        account_id: "acct_1",
+        message_id: "<msg@example.com>",
+        mail_from: "sender@example.com",
+        from_header: "Sender <sender@example.com>",
+        reply_to: null,
+        subject: "Hello",
+        text_body: "Hi there",
+        html_body: null,
+        size_bytes: 42,
+        thread_id: null,
+        labels: [],
+        read_at: null,
+        created_at: "2026-04-13T00:00:00Z",
+      },
+      lease_token: "lease_abc",
+      lease_expires_at: "2026-04-13T00:05:00Z",
+    };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => leased,
+      headers: new Headers(),
+    });
+
+    const result = await client.waitForNextMessage("mbx_001", { timeout: 30 });
+    expect(result).not.toBeNull();
+    expect(result?.lease_token).toBe("lease_abc");
+    expect(result?.data.id).toBe("msg_001");
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/v1/agent-mailboxes/mbx_001/messages/next");
+    expect(url).toContain("timeout=30");
+  });
+
+  it("returns null when the server responds with HTTP 408", async () => {
+    const client = new EuroMail({ apiKey: "em_test_key" });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 408,
+      json: async () => ({}),
+      text: async () => "",
+      headers: new Headers(),
+    });
+
+    const result = await client.waitForNextMessage("mbx_001", { timeout: 1 });
+    expect(result).toBeNull();
+  });
+});
+
+describe("ackMessage", () => {
+  it("POSTs the lease token to the ack endpoint", async () => {
+    const client = new EuroMail({ apiKey: "em_test_key" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
+
+    await client.ackMessage("mbx_001", "msg_001", "lease_abc");
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/v1/agent-mailboxes/mbx_001/messages/msg_001/ack");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({ lease_token: "lease_abc" });
+  });
+});
+
+describe("nackMessage", () => {
+  it("POSTs the lease token to the nack endpoint", async () => {
+    const client = new EuroMail({ apiKey: "em_test_key" });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 204,
+      json: async () => ({}),
+      headers: new Headers(),
+    });
+
+    await client.nackMessage("mbx_001", "msg_001", "lease_abc");
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("/v1/agent-mailboxes/mbx_001/messages/msg_001/nack");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body);
+    expect(body).toEqual({ lease_token: "lease_abc" });
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -70,6 +70,13 @@ import type {
   GdprEraseResponse,
   LinkClickStat,
   InsightReport,
+  AgentMailbox,
+  CreateAgentMailboxParams,
+  ListAgentMailboxesParams,
+  MailboxMessage,
+  ListMailboxMessagesParams,
+  WaitForNextMessageParams,
+  LeasedMessage,
 } from "./types.js";
 
 export interface EuroMailConfig {
@@ -654,6 +661,120 @@ export class EuroMail {
 
   async gdprErase(email: string): Promise<GdprEraseResponse> {
     return this.request<GdprEraseResponse>("DELETE", `/v1/gdpr/erase?email=${encodeURIComponent(email)}`);
+  }
+
+  // ---- Agent Mailbox Methods ----
+
+  async createMailbox(params?: CreateAgentMailboxParams): Promise<AgentMailbox> {
+    const result = await this.post<{ data: AgentMailbox }>("/v1/agent-mailboxes", params ?? {});
+    return result.data;
+  }
+
+  async listMailboxes(params?: ListAgentMailboxesParams): Promise<AgentMailbox[]> {
+    const query = new URLSearchParams();
+    if (params?.limit !== undefined) query.set("limit", String(params.limit));
+    if (params?.offset !== undefined) query.set("offset", String(params.offset));
+    const qs = query.toString();
+    const result = await this.get<{ data: AgentMailbox[] }>(
+      `/v1/agent-mailboxes${qs ? `?${qs}` : ""}`
+    );
+    return result.data;
+  }
+
+  async getMailbox(id: string): Promise<AgentMailbox> {
+    const result = await this.get<{ data: AgentMailbox }>(
+      `/v1/agent-mailboxes/${encodeURIComponent(id)}`
+    );
+    return result.data;
+  }
+
+  async deleteMailbox(id: string): Promise<void> {
+    await this.delete(`/v1/agent-mailboxes/${encodeURIComponent(id)}`);
+  }
+
+  async listMessages(
+    mailboxId: string,
+    params?: ListMailboxMessagesParams
+  ): Promise<MailboxMessage[]> {
+    const query = new URLSearchParams();
+    if (params?.status) query.set("status", params.status);
+    if (params?.limit !== undefined) query.set("limit", String(params.limit));
+    if (params?.offset !== undefined) query.set("offset", String(params.offset));
+    const qs = query.toString();
+    const result = await this.get<{ data: MailboxMessage[] }>(
+      `/v1/agent-mailboxes/${encodeURIComponent(mailboxId)}/messages${qs ? `?${qs}` : ""}`
+    );
+    return result.data;
+  }
+
+  /**
+   * Long-poll for the next message in a mailbox. Acquires a lease that must be
+   * released via `ackMessage` (success) or `nackMessage` (retry). Returns
+   * `null` when the server responds with HTTP 408 (no message arrived within
+   * the timeout window).
+   */
+  async waitForNextMessage(
+    mailboxId: string,
+    params?: WaitForNextMessageParams
+  ): Promise<LeasedMessage | null> {
+    const query = new URLSearchParams();
+    if (params?.timeout !== undefined) query.set("timeout", String(params.timeout));
+    const qs = query.toString();
+    const path = `/v1/agent-mailboxes/${encodeURIComponent(mailboxId)}/messages/next${qs ? `?${qs}` : ""}`;
+
+    // Dedicated code path: the long-poll endpoint returns HTTP 408 with no body
+    // when no message arrives. We treat that as a non-error `null` result so
+    // callers can simply re-invoke in a loop without catching.
+    const url = `${this.baseUrl}${path}`;
+    const controller = new AbortController();
+    // Give the network a little slack on top of the server-side long-poll
+    // timeout so the request isn't aborted right before the server responds.
+    const serverTimeoutMs = (params?.timeout ?? 30) * 1000;
+    const clientTimeoutMs = Math.max(this.timeout, serverTimeoutMs + 5_000);
+    const timer = setTimeout(() => controller.abort(), clientTimeoutMs);
+
+    try {
+      const response = await fetch(url, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          Accept: "application/json",
+        },
+        signal: controller.signal,
+      });
+
+      if (response.status === 408) {
+        return null;
+      }
+
+      if (!response.ok) {
+        throw await EuroMailError.fromResponse(response);
+      }
+
+      return (await response.json()) as LeasedMessage;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async deleteMessage(mailboxId: string, messageId: string): Promise<void> {
+    await this.delete(
+      `/v1/agent-mailboxes/${encodeURIComponent(mailboxId)}/messages/${encodeURIComponent(messageId)}`
+    );
+  }
+
+  async ackMessage(mailboxId: string, messageId: string, leaseToken: string): Promise<void> {
+    await this.post(
+      `/v1/agent-mailboxes/${encodeURIComponent(mailboxId)}/messages/${encodeURIComponent(messageId)}/ack`,
+      { lease_token: leaseToken }
+    );
+  }
+
+  async nackMessage(mailboxId: string, messageId: string, leaseToken: string): Promise<void> {
+    await this.post(
+      `/v1/agent-mailboxes/${encodeURIComponent(mailboxId)}/messages/${encodeURIComponent(messageId)}/nack`,
+      { lease_token: leaseToken }
+    );
   }
 
   // ---- HTTP Helpers ----

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,4 +98,11 @@ export type {
   InsightArea,
   InsightFinding,
   InsightReport,
+  AgentMailbox,
+  CreateAgentMailboxParams,
+  ListAgentMailboxesParams,
+  MailboxMessage,
+  ListMailboxMessagesParams,
+  WaitForNextMessageParams,
+  LeasedMessage,
 } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -819,3 +819,60 @@ export interface AuditLog {
   details: Record<string, unknown> | null;
   created_at: string;
 }
+
+// ---- Agent Mailbox Types ----
+
+export interface AgentMailbox {
+  id: string;
+  account_id: string;
+  local_part: string;
+  domain: string;
+  address: string;
+  display_name: string | null;
+  created_at: string;
+}
+
+export interface CreateAgentMailboxParams {
+  display_name?: string;
+  local_part?: string;
+  domain_id?: string;
+}
+
+export interface ListAgentMailboxesParams {
+  limit?: number;
+  offset?: number;
+}
+
+export interface MailboxMessage {
+  id: string;
+  mailbox_id: string;
+  account_id: string;
+  message_id: string | null;
+  mail_from: string;
+  from_header: string | null;
+  reply_to: string | null;
+  subject: string | null;
+  text_body: string | null;
+  html_body: string | null;
+  size_bytes: number;
+  thread_id: string | null;
+  labels: string[];
+  read_at: string | null;
+  created_at: string;
+}
+
+export interface ListMailboxMessagesParams {
+  status?: "all" | "unread" | "read";
+  limit?: number;
+  offset?: number;
+}
+
+export interface WaitForNextMessageParams {
+  timeout?: number;
+}
+
+export interface LeasedMessage {
+  data: MailboxMessage;
+  lease_token: string;
+  lease_expires_at: string;
+}


### PR DESCRIPTION
## Summary

- Native SDK methods for EuroMail agent mailboxes: create / list / get / delete mailboxes, list messages, long-poll for the next message, ack / nack / delete messages.
- `waitForNextMessage` uses a dedicated HTTP path so HTTP 408 long-poll timeouts surface as `null` (callers can loop without try/catch); all other methods reuse the existing `request`/`requestRaw` helpers.
- New types: `AgentMailbox`, `MailboxMessage`, `LeasedMessage`, plus param types.
- README: replaces the raw-fetch example with idiomatic SDK usage; keeps the guide link.
- CHANGELOG: adds 0.2.0 entry; bumps `package.json` from 0.1.2 to 0.2.0 (minor, no breaking change).
- Tests: adds `src/__tests__/agent-mailboxes.test.ts` covering `createMailbox`, `waitForNextMessage` (200 and 408), and `ackMessage` body payload.

## Design decisions

- `createMailbox`, `listMailboxes`, `getMailbox`, `listMessages` all unwrap the `{ data: ... }` envelope to match the rest of the SDK. `waitForNextMessage` intentionally returns the full `LeasedMessage` envelope since callers need `lease_token`.
- For 408 handling, rather than refactoring the shared HTTP helper or threading an "expected statuses" flag, the long-poll method has its own small fetch block. One special case, no collateral damage.
- Client-side abort timer for `waitForNextMessage` is `max(config.timeout, serverTimeout + 5s)` so the client doesn't abort right before the server's long-poll window closes.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npx vitest run src/__tests__/agent-mailboxes.test.ts` — all 6 tests pass
- [x] Full suite: 50/51 pass; the one pre-existing failure in `client.test.ts` (stale error-message assertion) is unrelated to this change
- [ ] Smoke-test against a live mailbox after publish

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>