### PR TITLE
fix(errors): parse nested error body and route validation errors by type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.log
+.DS_Store
+.env
+.env.local
+coverage/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@euromail/sdk",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@euromail/sdk",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -141,4 +141,84 @@ describe("error handling", () => {
       expect((err as EuroMailError).message).toBe("Bad Gateway");
     }
   });
+
+  it("parses nested error body and preserves server message", async () => {
+    const client = new EuroMail({ apiKey: "em_test_key" });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: async () => ({
+        error: {
+          code: "internal_error",
+          message: "Database connection failed",
+          type: "server_error",
+          docs_url: "https://euromail.dev/docs/errors",
+        },
+      }),
+      headers: new Headers(),
+    });
+    try {
+      await client.getAccount();
+    } catch (err) {
+      expect(err).toBeInstanceOf(EuroMailError);
+      expect((err as EuroMailError).status).toBe(500);
+      expect((err as EuroMailError).code).toBe("internal_error");
+      expect((err as EuroMailError).message).toBe("Database connection failed");
+      expect((err as EuroMailError).docsUrl).toBe("https://euromail.dev/docs/errors");
+    }
+  });
+
+  it("routes HTTP 400 with validation_error type to ValidationError", async () => {
+    const client = new EuroMail({ apiKey: "em_test_key" });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => ({
+        error: {
+          code: "VALIDATION_ERROR",
+          message: "Domain 'some-unverified-domain.tld' is not verified.",
+          type: "validation_error",
+          docs_url: "https://euromail.dev/docs/#request-format",
+        },
+      }),
+      headers: new Headers(),
+    });
+    try {
+      await client.sendEmail({
+        from: "noreply@some-unverified-domain.tld",
+        to: "r@e.com",
+        subject: "x",
+        html_body: "<p>x</p>",
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(ValidationError);
+      expect((err as ValidationError).code).toBe("VALIDATION_ERROR");
+      expect((err as ValidationError).message).toBe(
+        "Domain 'some-unverified-domain.tld' is not verified.",
+      );
+      expect((err as ValidationError).docsUrl).toBe(
+        "https://euromail.dev/docs/#request-format",
+      );
+    }
+  });
+
+  it("still parses flat error body for forward compat", async () => {
+    const client = new EuroMail({ apiKey: "em_test_key" });
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: async () => ({ code: "flat_error", message: "Flat body message" }),
+      headers: new Headers(),
+    });
+    try {
+      await client.getAccount();
+    } catch (err) {
+      expect(err).toBeInstanceOf(EuroMailError);
+      expect((err as EuroMailError).code).toBe("flat_error");
+      expect((err as EuroMailError).message).toBe("Flat body message");
+    }
+  });
 });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,49 +1,66 @@
+interface ApiErrorBody {
+  error?: { code?: string; message?: string; type?: string; docs_url?: string };
+  code?: string;
+  message?: string;
+  type?: string;
+  docs_url?: string;
+}
+
 export class EuroMailError extends Error {
   public readonly status: number;
   public readonly code: string;
+  public readonly docsUrl: string | null;
 
-  constructor(status: number, code: string, message: string) {
+  constructor(status: number, code: string, message: string, docsUrl: string | null = null) {
     super(message);
     this.name = "EuroMailError";
     this.status = status;
     this.code = code;
+    this.docsUrl = docsUrl;
   }
 
   static async fromResponse(response: Response): Promise<EuroMailError> {
-    let body: { code?: string; message?: string };
+    let raw: ApiErrorBody;
     try {
-      body = (await response.json()) as { code?: string; message?: string };
+      raw = (await response.json()) as ApiErrorBody;
     } catch {
-      body = { code: "unknown", message: response.statusText };
+      raw = {};
     }
 
-    const code = body.code ?? "unknown";
-    const message = body.message ?? response.statusText;
+    const err = raw.error ?? raw;
+    const code = err.code ?? "unknown";
+    const message = err.message ?? response.statusText;
+    const type = err.type;
+    const docsUrl = err.docs_url ?? null;
     const status = response.status;
+
+    if (type === "validation_error" || code === "VALIDATION_ERROR") {
+      return new ValidationError(code, message, docsUrl);
+    }
 
     switch (status) {
       case 401:
-        return new AuthenticationError(message);
+        return new AuthenticationError(message, docsUrl);
       case 422:
-        return new ValidationError(code, message);
+        return new ValidationError(code, message, docsUrl);
       case 429:
-        return new RateLimitError(message, parseRetryAfter(response));
+        return new RateLimitError(message, parseRetryAfter(response), docsUrl);
       default:
-        return new EuroMailError(status, code, message);
+        return new EuroMailError(status, code, message, docsUrl);
     }
   }
 }
 
 export class AuthenticationError extends EuroMailError {
-  constructor(message = "Invalid API key") {
-    super(401, "authentication_error", message);
+  constructor(message = "Invalid API key", docsUrl: string | null = null) {
+    super(401, "authentication_error", message, docsUrl);
     this.name = "AuthenticationError";
   }
 }
 
 export class ValidationError extends EuroMailError {
-  constructor(code: string, message: string) {
-    super(422, code, message);
+  constructor(code: string, message: string, docsUrl: string | null = null) {
+    super(422, code, message, docsUrl);
     this.name = "ValidationError";
   }
 }
@@ -51,8 +68,12 @@ export class ValidationError extends EuroMailError {
 export class RateLimitError extends EuroMailError {
   public readonly retryAfter: number | null;
 
-  constructor(message = "Rate limit exceeded", retryAfter: number | null = null) {
-    super(429, "rate_limit_exceeded", message);
+  constructor(
+    message = "Rate limit exceeded",
+    retryAfter: number | null = null,
+    docsUrl: string | null = null,
+  ) {
+    super(429, "rate_limit_exceeded", message, docsUrl);
     this.name = "RateLimitError";
     this.retryAfter = retryAfter;
   }


### PR DESCRIPTION
## Summary
- `EuroMailError.fromResponse` now accepts both nested `{error: {...}}` and flat `{code, message}` body shapes, so server messages are preserved instead of collapsing to `response.statusText`.
- `ValidationError` is now routed based on the server's `type: "validation_error"` / `code: "VALIDATION_ERROR"`, not hardcoded HTTP 422 — matches what the API actually returns (HTTP 400).
- `docsUrl` is now exposed on `EuroMailError` (and subclasses) so consumers can point users at the relevant docs page.
- Added `.gitignore` (was missing — `dist/` and `node_modules/` were untracked only by accident).

Closes #4

## Test plan
- [x] `npm run test:run` — all 48 tests pass, including 3 new cases: nested body parsing, HTTP 400 + validation_error routing, flat body forward-compat
- [x] `npm run build` — clean tsc build
- [ ] Smoke test against real `api.euromail.dev` with an unverified sender domain to confirm the server message now surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)