### PR TITLE
feat(client): auto-retry on 5xx/429/network errors with idempotency support

### DIFF
--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
 
 describe("error handling", () => {
   it("throws AuthenticationError on 401", async () => {
-    const client = new EuroMail({ apiKey: "em_bad_key" });
+    const client = new EuroMail({ apiKey: "em_bad_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 401,
@@ -28,7 +28,7 @@ describe("error handling", () => {
   });
 
   it("AuthenticationError has correct status and code", async () => {
-    const client = new EuroMail({ apiKey: "em_bad_key" });
+    const client = new EuroMail({ apiKey: "em_bad_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 401,
@@ -47,7 +47,7 @@ describe("error handling", () => {
   });
 
   it("throws ValidationError on 422", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 422,
@@ -61,7 +61,7 @@ describe("error handling", () => {
   });
 
   it("ValidationError has correct code and message", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 422,
@@ -80,7 +80,7 @@ describe("error handling", () => {
   });
 
   it("throws RateLimitError on 429", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 429,
@@ -94,7 +94,7 @@ describe("error handling", () => {
   });
 
   it("RateLimitError includes retryAfter from header", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 429,
@@ -111,7 +111,7 @@ describe("error handling", () => {
   });
 
   it("throws generic EuroMailError on other status codes", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
@@ -123,7 +123,7 @@ describe("error handling", () => {
   });
 
   it("handles non-JSON error responses", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 502,
@@ -143,7 +143,7 @@ describe("error handling", () => {
   });
 
   it("parses nested error body and preserves server message", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
@@ -170,7 +170,7 @@ describe("error handling", () => {
   });
 
   it("routes HTTP 400 with validation_error type to ValidationError", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 400,
@@ -205,7 +205,7 @@ describe("error handling", () => {
   });
 
   it("captures request id from response headers", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
@@ -222,7 +222,7 @@ describe("error handling", () => {
   });
 
   it("falls back to request-id header variant", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,
@@ -238,7 +238,7 @@ describe("error handling", () => {
   });
 
   it("still parses flat error body for forward compat", async () => {
-    const client = new EuroMail({ apiKey: "em_test_key" });
+    const client = new EuroMail({ apiKey: "em_test_key", maxRetries: 0 });
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 500,

--- a/src/__tests__/retry.test.ts
+++ b/src/__tests__/retry.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EuroMail } from "../client.js";
+import { EuroMailError } from "../errors.js";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function okJson(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+    headers: new Headers(),
+  };
+}
+
+function errorJson(status: number, body: unknown, headers?: Record<string, string>) {
+  return {
+    ok: false,
+    status,
+    statusText: "Error",
+    json: async () => body,
+    headers: new Headers(headers ?? {}),
+  };
+}
+
+describe("retry behavior", () => {
+  it("retries 503 then succeeds on second attempt", async () => {
+    const client = new EuroMail({
+      apiKey: "em_test_key",
+      maxRetries: 2,
+      retryBaseDelayMs: 1,
+    });
+    mockFetch
+      .mockResolvedValueOnce(errorJson(503, { error: { code: "unavail", message: "nope" } }))
+      .mockResolvedValueOnce(okJson({ data: { id: "acct_1" } }));
+
+    const result = await client.getAccount();
+    expect(result).toEqual({ id: "acct_1" });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries up to maxRetries+1 total attempts then throws", async () => {
+    const client = new EuroMail({
+      apiKey: "em_test_key",
+      maxRetries: 2,
+      retryBaseDelayMs: 1,
+    });
+    mockFetch.mockResolvedValue(
+      errorJson(500, { error: { code: "boom", message: "boom" } }),
+    );
+
+    await expect(client.getAccount()).rejects.toThrow(EuroMailError);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry POST without idempotency key", async () => {
+    const client = new EuroMail({
+      apiKey: "em_test_key",
+      maxRetries: 2,
+      retryBaseDelayMs: 1,
+    });
+    mockFetch.mockResolvedValueOnce(
+      errorJson(500, { error: { code: "boom", message: "boom" } }),
+    );
+
+    await expect(
+      client.sendEmail({ from: "a@b.com", to: "c@d.com", subject: "s", text_body: "t" }),
+    ).rejects.toThrow(EuroMailError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries POST when idempotency key is provided", async () => {
+    const client = new EuroMail({
+      apiKey: "em_test_key",
+      maxRetries: 2,
+      retryBaseDelayMs: 1,
+    });
+    mockFetch
+      .mockResolvedValueOnce(errorJson(503, { error: { code: "x", message: "x" } }))
+      .mockResolvedValueOnce(okJson({ data: { id: "em_1" } }));
+
+    const result = await client.sendEmail(
+      { from: "a@b.com", to: "c@d.com", subject: "s", text_body: "t" },
+      { idempotencyKey: "key_123" },
+    );
+    expect(result).toEqual({ id: "em_1" });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers["Idempotency-Key"]).toBe("key_123");
+  });
+
+  it("does not retry 4xx errors (except 429)", async () => {
+    const client = new EuroMail({
+      apiKey: "em_test_key",
+      maxRetries: 2,
+      retryBaseDelayMs: 1,
+    });
+    mockFetch.mockResolvedValueOnce(
+      errorJson(400, { error: { code: "bad", message: "bad" } }),
+    );
+
+    await expect(client.getAccount()).rejects.toThrow(EuroMailError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries 429 and respects retry-after header", async () => {
+    const client = new EuroMail({
+      apiKey: "em_test_key",
+      maxRetries: 2,
+      retryBaseDelayMs: 1,
+    });
+    mockFetch
+      .mockResolvedValueOnce(
+        errorJson(429, { error: { code: "rate", message: "rate" } }, { "retry-after": "0" }),
+      )
+      .mockResolvedValueOnce(okJson({ data: { id: "acct_1" } }));
+
+    await client.getAccount();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on network error", async () => {
+    const client = new EuroMail({
+      apiKey: "em_test_key",
+      maxRetries: 2,
+      retryBaseDelayMs: 1,
+    });
+    mockFetch
+      .mockRejectedValueOnce(new TypeError("fetch failed"))
+      .mockResolvedValueOnce(okJson({ data: { id: "acct_1" } }));
+
+    const result = await client.getAccount();
+    expect(result).toEqual({ id: "acct_1" });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry when user aborts", async () => {
+    const client = new EuroMail({
+      apiKey: "em_test_key",
+      maxRetries: 2,
+      retryBaseDelayMs: 1,
+    });
+    const controller = new AbortController();
+    controller.abort();
+    mockFetch.mockImplementation(() => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      return Promise.reject(err);
+    });
+
+    await expect(
+      client.sendEmail(
+        { from: "a@b.com", to: "c@d.com", subject: "s", text_body: "t" },
+        { idempotencyKey: "k", signal: controller.signal },
+      ),
+    ).rejects.toThrow();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -84,11 +84,27 @@ export interface EuroMailConfig {
   apiKey?: string;
   baseUrl?: string;
   timeout?: number;
+  /** Maximum automatic retries for network errors, 429, and 5xx responses. Default 2. */
+  maxRetries?: number;
+  /** Base delay (ms) for exponential backoff between retries. Default 200. */
+  retryBaseDelayMs?: number;
+}
+
+export interface RequestOptions {
+  /** Per-call idempotency key sent as `Idempotency-Key` header. Enables safe POST retries. */
+  idempotencyKey?: string;
+  /** Abort signal for cancellation. Combined with the internal timeout. */
+  signal?: AbortSignal;
 }
 
 const DEFAULT_BASE_URL = "https://api.euromail.dev";
 const DEFAULT_TIMEOUT = 30_000;
+const DEFAULT_MAX_RETRIES = 2;
+const DEFAULT_RETRY_BASE_MS = 200;
+const MAX_RETRY_DELAY_MS = 10_000;
 const USER_AGENT = `euromail-sdk-js/${SDK_VERSION}`;
+const RETRIABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+const IDEMPOTENT_METHODS = new Set(["GET", "HEAD", "PUT", "DELETE", "OPTIONS"]);
 
 function resolveBaseUrl(explicit?: string): string {
   if (explicit) return explicit;
@@ -102,6 +118,8 @@ export class EuroMail {
   private readonly apiKey: string;
   private readonly baseUrl: string;
   private readonly timeout: number;
+  private readonly maxRetries: number;
+  private readonly retryBaseDelayMs: number;
 
   constructor(config: EuroMailConfig = {}) {
     const resolvedApiKey =
@@ -119,6 +137,8 @@ export class EuroMail {
       console.warn("WARNING: EuroMail base URL does not use HTTPS. API keys will be sent in cleartext.");
     }
     this.timeout = config.timeout ?? DEFAULT_TIMEOUT;
+    this.maxRetries = Math.max(0, config.maxRetries ?? DEFAULT_MAX_RETRIES);
+    this.retryBaseDelayMs = Math.max(0, config.retryBaseDelayMs ?? DEFAULT_RETRY_BASE_MS);
   }
 
   // ---- Account Methods ----
@@ -139,13 +159,32 @@ export class EuroMail {
 
   // ---- Email Methods ----
 
-  async sendEmail(params: SendEmailParams): Promise<SendEmailResponse> {
-    const result = await this.post<{ data: SendEmailResponse }>("/v1/emails", params);
+  /**
+   * Send a transactional email. Pass `options.idempotencyKey` to allow the SDK
+   * to safely retry on transient failures (network errors, 429, 5xx); without
+   * a key, POSTs are sent once and not retried.
+   */
+  async sendEmail(
+    params: SendEmailParams,
+    options?: RequestOptions,
+  ): Promise<SendEmailResponse> {
+    const result = await this.post<{ data: SendEmailResponse }>(
+      "/v1/emails",
+      params,
+      options,
+    );
     return result.data;
   }
 
-  async sendBatch(params: SendBatchParams): Promise<SendBatchResponse> {
-    return this.post<SendBatchResponse>("/v1/emails/batch", params);
+  /**
+   * Send a batch of emails in one request. Pass `options.idempotencyKey` to
+   * allow the SDK to safely retry on transient failures.
+   */
+  async sendBatch(
+    params: SendBatchParams,
+    options?: RequestOptions,
+  ): Promise<SendBatchResponse> {
+    return this.post<SendBatchResponse>("/v1/emails/batch", params, options);
   }
 
   async getEmail(emailId: string): Promise<EmailDetail> {
@@ -797,97 +836,139 @@ export class EuroMail {
     return params;
   }
 
-  private async requestRaw(method: string, path: string, body?: unknown): Promise<Response> {
+  private async doFetch(
+    method: string,
+    path: string,
+    body: unknown | undefined,
+    options: RequestOptions & { acceptJson: boolean },
+  ): Promise<Response> {
     const url = `${this.baseUrl}${path}`;
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), this.timeout);
+    const idempotencyKey = options.idempotencyKey;
+    const canRetry = IDEMPOTENT_METHODS.has(method) || idempotencyKey !== undefined;
+    const maxAttempts = canRetry ? this.maxRetries + 1 : 1;
 
-    try {
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const isLastAttempt = attempt + 1 >= maxAttempts;
+      const { signal, cleanup } = this.buildSignal(options.signal);
+
       const headers: Record<string, string> = {
         Authorization: `Bearer ${this.apiKey}`,
         "User-Agent": USER_AGENT,
       };
+      if (options.acceptJson) headers["Accept"] = "application/json";
+      if (idempotencyKey) headers["Idempotency-Key"] = idempotencyKey;
 
-      const init: RequestInit = {
-        method,
-        headers,
-        signal: controller.signal,
-      };
-
+      const init: RequestInit = { method, headers, signal };
       if (body !== undefined) {
         headers["Content-Type"] = "application/json";
         headers["Accept"] = "application/json";
         init.body = JSON.stringify(body);
       }
 
-      const response = await fetch(url, init);
+      let response: Response;
+      try {
+        response = await fetch(url, init);
+      } catch (err) {
+        cleanup();
+        if (options.signal?.aborted || isLastAttempt) throw err;
+        await this.sleep(this.backoffDelay(attempt, null));
+        continue;
+      }
+      cleanup();
 
-      if (!response.ok) {
-        throw await EuroMailError.fromResponse(response);
+      if (response.ok) return response;
+
+      if (RETRIABLE_STATUSES.has(response.status) && !isLastAttempt) {
+        const retryAfter = parseRetryAfterSeconds(response.headers.get("retry-after"));
+        await this.sleep(this.backoffDelay(attempt, retryAfter));
+        continue;
       }
 
-      return response;
-    } finally {
-      clearTimeout(timer);
+      throw await EuroMailError.fromResponse(response);
     }
+
+    // Unreachable: the loop either returns, throws, or continues for exactly maxAttempts iterations.
+    throw new Error("euromail: retry loop exited without result");
   }
 
-  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
-    const url = `${this.baseUrl}${path}`;
+  private buildSignal(userSignal?: AbortSignal): { signal: AbortSignal; cleanup: () => void } {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeout);
+    let onUserAbort: (() => void) | null = null;
 
-    try {
-      const headers: Record<string, string> = {
-        Authorization: `Bearer ${this.apiKey}`,
-        Accept: "application/json",
-        "User-Agent": USER_AGENT,
-      };
-
-      const init: RequestInit = {
-        method,
-        headers,
-        signal: controller.signal,
-      };
-
-      if (body !== undefined) {
-        headers["Content-Type"] = "application/json";
-        init.body = JSON.stringify(body);
+    if (userSignal) {
+      if (userSignal.aborted) {
+        controller.abort();
+      } else {
+        onUserAbort = () => controller.abort();
+        userSignal.addEventListener("abort", onUserAbort, { once: true });
       }
-
-      const response = await fetch(url, init);
-
-      if (!response.ok) {
-        throw await EuroMailError.fromResponse(response);
-      }
-
-      if (response.status === 204) {
-        return undefined as T;
-      }
-
-      return (await response.json()) as T;
-    } finally {
-      clearTimeout(timer);
     }
+
+    return {
+      signal: controller.signal,
+      cleanup: () => {
+        clearTimeout(timer);
+        if (userSignal && onUserAbort) userSignal.removeEventListener("abort", onUserAbort);
+      },
+    };
   }
 
-  private get<T>(path: string): Promise<T> {
-    return this.request<T>("GET", path);
+  private backoffDelay(attempt: number, retryAfterSeconds: number | null): number {
+    if (retryAfterSeconds !== null) {
+      return Math.min(retryAfterSeconds * 1000, MAX_RETRY_DELAY_MS);
+    }
+    const exp = this.retryBaseDelayMs * Math.pow(2, attempt);
+    const jitter = Math.random() * this.retryBaseDelayMs;
+    return Math.min(exp + jitter, MAX_RETRY_DELAY_MS);
   }
 
-  private post<T>(path: string, body: unknown): Promise<T> {
-    return this.request<T>("POST", path, body);
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  private put<T>(path: string, body: unknown): Promise<T> {
-    return this.request<T>("PUT", path, body);
+  private requestRaw(method: string, path: string, body?: unknown): Promise<Response> {
+    return this.doFetch(method, path, body, { acceptJson: false });
   }
 
-  private patch<T>(path: string, body: unknown): Promise<T> {
-    return this.request<T>("PATCH", path, body);
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    options: RequestOptions = {},
+  ): Promise<T> {
+    const response = await this.doFetch(method, path, body, { ...options, acceptJson: true });
+    if (response.status === 204) return undefined as T;
+    return (await response.json()) as T;
   }
 
-  private delete(path: string): Promise<void> {
-    return this.request<void>("DELETE", path);
+  private get<T>(path: string, options?: RequestOptions): Promise<T> {
+    return this.request<T>("GET", path, undefined, options);
   }
+
+  private post<T>(path: string, body: unknown, options?: RequestOptions): Promise<T> {
+    return this.request<T>("POST", path, body, options);
+  }
+
+  private put<T>(path: string, body: unknown, options?: RequestOptions): Promise<T> {
+    return this.request<T>("PUT", path, body, options);
+  }
+
+  private patch<T>(path: string, body: unknown, options?: RequestOptions): Promise<T> {
+    return this.request<T>("PATCH", path, body, options);
+  }
+
+  private delete(path: string, options?: RequestOptions): Promise<void> {
+    return this.request<void>("DELETE", path, undefined, options);
+  }
+}
+
+function parseRetryAfterSeconds(header: string | null): number | null {
+  if (!header) return null;
+  const asInt = parseInt(header, 10);
+  if (!isNaN(asInt)) return asInt;
+  const asDate = Date.parse(header);
+  if (isNaN(asDate)) return null;
+  const seconds = Math.max(0, Math.ceil((asDate - Date.now()) / 1000));
+  return seconds;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { EuroMail } from "./client.js";
-export type { EuroMailConfig } from "./client.js";
+export type { EuroMailConfig, RequestOptions } from "./client.js";
 
 export {
   EuroMailError,


### PR DESCRIPTION
## Summary
The SDK now automatically retries transient failures with exponential backoff + jitter.

**Retry conditions:** network errors (fetch throws), HTTP 429, 500, 502, 503, 504.

**Retry safety:**
- `GET`, `HEAD`, `PUT`, `DELETE`, `OPTIONS` are retried unconditionally (HTTP-idempotent)
- `POST` is retried **only** when the caller supplies an `Idempotency-Key`
- 429 responses honor `Retry-After` header (both seconds and HTTP-date forms)
- User-supplied `AbortSignal` short-circuits the retry loop

**New config options** (`EuroMailConfig`):
- `maxRetries` (default `2`) — retry budget on top of the initial attempt
- `retryBaseDelayMs` (default `200`) — base for exponential backoff

**Usage:**
```ts
const em = new EuroMail({ apiKey, maxRetries: 3 });

// GET auto-retries:
await em.getAccount();

// POST retries only with an idempotency key:
await em.sendEmail(params, { idempotencyKey: randomUUID() });

// Cancel mid-retry:
const controller = new AbortController();
await em.sendEmail(params, { signal: controller.signal, idempotencyKey: "k" });
```

## Additional cleanup
- HTTP helper duplication eliminated — `request`, `requestRaw`, and future calls all route through one `doFetch` method
- `waitForNextMessage` intentionally stays outside retry (long-poll is already its own "retry")

## Test plan
- [x] `npm run test:run` — 68/68 tests pass, including 8 new retry cases (503→200, exhaust + throw, POST without key, POST with key, 4xx no-retry, 429 + Retry-After, network error, user abort)
- [x] `npm run build` — clean tsc build

🤖 Generated with [Claude Code](https://claude.com/claude-code)