### PR TITLE
fix(ci): stop unsetting NODE_AUTH_TOKEN before npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
             echo "Version $LOCAL already published, skipping"
           else
             echo "Publishing $LOCAL (registry has $REMOTE)"
-            unset NODE_AUTH_TOKEN
             npm publish --access public --provenance
           fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

The `Publish to npm` step unsets `NODE_AUTH_TOKEN` before running `npm publish --access public --provenance`. Without the token, npm has no authority to write to the `@euromail` scope and the registry returns:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@euromail%2fsdk - Not found
```

This is why `0.2.0` never reached npm despite the `test` job going green and the main-branch tag being cut. The last four pushes to `main` (#6, #7, #8, #9) all failed at this step.

## Why the original pattern doesn't work

`--provenance` does **not** replace the publish credential. It adds an OIDC-signed attestation on top of an otherwise authenticated publish. An unauthenticated publish only works if the npm account has explicitly opted into **trusted publishing** for this exact repo + workflow, which `@euromail/sdk` hasn't.

The [npm docs](https://docs.npmjs.com/generating-provenance-statements) show `NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}` and `--provenance` used together. Token + OIDC are complementary, not alternatives.

## Fix

- Keep `--provenance` so releases remain signed
- Drop the `unset NODE_AUTH_TOKEN` line
- Expose the existing `NPM_TOKEN` secret to the publish step via `env:` so `actions/setup-node`'s `.npmrc` injection has something to use

## Impact

After merge, the next push to `main` triggers the workflow. Version detection sees `0.2.0` ≠ `0.1.2` on the registry and publishes `@euromail/sdk@0.2.0` with signed provenance. Issue #4 becomes available to consumers via `npm install @euromail/sdk@0.2.0`.

## Test plan

- [ ] Merge to `main`
- [ ] Observe CI succeeds on the resulting push
- [ ] `npm view @euromail/sdk version` returns `0.2.0`
- [ ] `npm install @euromail/sdk@0.2.0` in a scratch project works