### PR TITLE
Revert #10: restore OIDC trusted publishing for npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
             echo "Version $LOCAL already published, skipping"
           else
             echo "Publishing $LOCAL (registry has $REMOTE)"
+            unset NODE_AUTH_TOKEN
             npm publish --access public --provenance
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Reverts #10. #10 assumed `NPM_TOKEN` existed as a repo secret — it doesn't. The original design uses **npm trusted publishing via OIDC** (see commit 61a32e2 from 2026-04-04), which is how `0.1.2` was actually published. The `unset NODE_AUTH_TOKEN` line was deliberate in that setup — it forces `npm publish --provenance` to exchange the GitHub OIDC token for a short-lived npm publish credential, with no long-lived token stored anywhere.

## Why #10 failed

My assumption that `NPM_TOKEN` existed was wrong:

```
$ gh secret list --repo kalle-works/euromail-typescript
(empty)
```

So #10 produced `ENEEDAUTH - need auth` on the publish step: token was expected but resolved to empty string.

## Why the original (OIDC) also stopped working

`0.1.2` was published successfully on 2026-04-04 via OIDC. Since then the Trusted Publisher rule for `@euromail/sdk` on npmjs.com has either been removed, or the workflow path has drifted from whatever was registered. Result: `404 Not Found - PUT /@euromail%2fsdk` on every push since.

## What's needed on npmjs.com after this merge

1. npmjs.com → `@euromail` organization → `@euromail/sdk` package → Settings → **Trusted Publishers**
2. Add a GitHub Actions publisher:
   - Repository: `kalle-works/euromail-typescript`
   - Workflow filename: `ci.yml`
   - Environment: (leave blank)

After that's in place, any push to `main` with a bumped version publishes `0.2.0` with signed provenance, no long-lived tokens stored.

## Test plan

- [ ] Merge this revert
- [ ] Configure Trusted Publisher on npmjs.com
- [ ] Observe next push to `main` succeeds
- [ ] `npm view @euromail/sdk version` returns `0.2.0`