### PR TITLE
fix(ci): upgrade npm to enable OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm run build --if-present
+      # Node 22 ships with npm 10.x. OIDC trusted publishing requires npm >= 11.5.1.
+      - run: npm install -g npm@latest
       - name: Publish if version changed
         run: |
           LOCAL=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary

Adds `npm install -g npm@latest` before `npm publish` so the runner uses npm 11.5.1+, which is required for the OIDC → publish-credential exchange that powers trusted publishing.

## Why #11's revert wasn't enough

After merging #11 (restoring the pre-#10 OIDC flow) and configuring the Trusted Publisher rule on npmjs.com, the next `main` push still failed with:

```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm notice publish Provenance statement published to transparency log: https://search.sigstore.dev/?logIndex=1342462551
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/@euromail%2fsdk
```

Provenance gets signed (sigstore entry written), so OIDC itself works, but the final PUT to the registry goes out unauthenticated. That's the signature of "npm CLI too old to exchange OIDC for publish creds."

The runner logs confirm:
```
node: v22.22.2
npm: 10.9.7
```

npm added native OIDC trusted-publishing support in **11.5.1** (September 2025). npm 10.9.7 can sign provenance (that landed in 9.5) but can't perform the token exchange, so it ends up calling the publish API with no auth — hence the 404.

## History

Commit 17c1004 (2026-04-04) removed this same `npm install -g npm@latest` step with the rationale *"Node 22 ships with npm that supports trusted publishing natively."* That claim is incorrect — Node 22's bundled npm is 10.x, not 11.x. The one successful publish (0.1.2) was in the short window when the upgrade step existed, and every push since has failed.

## Test plan

- [ ] Merge this PR
- [ ] Observe CI succeeds on the resulting `main` push
- [ ] `npm view @euromail/sdk version` returns `0.2.0`
- [ ] `npm install @euromail/sdk@0.2.0` works in a scratch project