### PR TITLE
fix(ci): use npx to run npm@latest publish (avoid in-place upgrade bug)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
       - run: npm run build --if-present
-      # Node 22 ships with npm 10.x. OIDC trusted publishing requires npm >= 11.5.1.
-      - run: npm install -g npm@latest
       - name: Publish if version changed
+        # Node 22 ships with npm 10.x, but OIDC trusted publishing needs
+        # npm >= 11.5.1. `npm install -g npm@latest` breaks mid-upgrade
+        # (promise-retry gets pulled out from under the running process),
+        # so use npx to run a fresh npm@latest without replacing the one
+        # on disk.
         run: |
           LOCAL=$(node -p "require('./package.json').version")
           REMOTE=$(npm view @euromail/sdk version 2>/dev/null || echo "0.0.0")
@@ -46,5 +49,5 @@ jobs:
           else
             echo "Publishing $LOCAL (registry has $REMOTE)"
             unset NODE_AUTH_TOKEN
-            npm publish --access public --provenance
+            npx -y npm@latest publish --access public --provenance
           fi


### PR DESCRIPTION
## Summary

#12 added `npm install -g npm@latest` before `npm publish` to get the npm version that supports OIDC trusted publishing. It fails with:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
\`\`\`

This is npm's well-known in-place self-upgrade race: npm removes one of its own transitive deps (`promise-retry`, used by arborist's reify-output path) before the new version is fully installed, and the running npm can't resolve it to finish the install.

This is also why commit 17c1004 originally killed the `npm install -g npm@latest` step — but that left us on npm 10.x which can't do trusted publishing (the PR train #10/#11/#12 we just went through).

## Fix

Use `npx -y npm@latest publish` instead. npx fetches a fresh `npm@latest` into a temp dir and runs `publish` from there. The installed npm stays on 10.9.7; nothing gets overwritten mid-operation, so the self-upgrade race can't happen. npx caches the downloaded package, so there's no per-run cold-start cost beyond the first.

## Test plan

- [ ] Merge
- [ ] Next `main` push publishes `@euromail/sdk@0.2.0` with signed provenance
- [ ] `npm view @euromail/sdk version` returns `0.2.0`